### PR TITLE
added templates for testing file and roadie-utils actions

### DIFF
--- a/templates/built-in-file-actions/README.md
+++ b/templates/built-in-file-actions/README.md
@@ -1,0 +1,7 @@
+# Built In File Actions:
+
+## Delete a file from the workspace
+This template uses the `fs:delete` action which deletes files and directories from the workspace.
+
+## Rename a file within the workspace 
+This template uses the `fs:rename` action which renames files and directories within the workspace.

--- a/templates/built-in-file-actions/delete-file.yaml
+++ b/templates/built-in-file-actions/delete-file.yaml
@@ -1,0 +1,45 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: delete-file-template-example
+  title: Delete a File
+  description: Delete a file on the given path in the workspace.
+spec:
+  owner: janus-authors
+  system: janus-idp
+  type: service
+
+  parameters:
+    - title: Repository Information
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: File Details
+      properties:
+        path:
+          title: Path
+          type: string
+          description: The path to the file you want to delete
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:plain
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+    - id: delete-file
+      name: Delete File
+      action: fs:delete
+      input:
+        files:
+          - ${{ parameters.path }}
+    - id: log-message
+      name: List all files in the workspace
+      action: debug:log
+      input:
+        listWorkspace: true

--- a/templates/built-in-file-actions/rename-file.yaml
+++ b/templates/built-in-file-actions/rename-file.yaml
@@ -1,0 +1,50 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: rename-file-template-example
+  title: Rename a file
+  description: Rename a file on the given path in the workspace
+spec:
+  owner: janus-authors
+  system: janus-idp
+  type: service
+
+  parameters:
+    - title: Repository Data
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: File Details
+      properties:
+        path:
+          title: Path
+          type: string
+          description: The path to the file you want to rename
+        newName:
+          title: New File Name
+          type: string
+          description: Provide your file's new name
+
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:template
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+    - id: rename-file
+      name: Rename File
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ parameters.path }}
+            to: ${{ parameters.newName }}
+    - id: list-all-files
+      name: List all files
+      input:
+        listWorkspace: true

--- a/templates/roadie-utils-actions/README.md
+++ b/templates/roadie-utils-actions/README.md
@@ -1,0 +1,21 @@
+# Roadie utils actions for the scaffolder-backend
+
+- [Setup](https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md#setup)
+
+NOTE: If the GitHub repository used with these templates is not public, [setup GitHub Integration](https://backstage.io/docs/integrations/github/github-apps/) 
+
+##  Read contents of a file
+
+This template uses the `roadiehq:utils:fs:parse` action which reads a file from the workspace and optionally parses it.
+
+## Zip content of a path
+
+This template uses the `roadiehq:utils:zip` action which zips the content of the given path.
+
+## Parse and Transform JSON
+
+This template uses the `roadiehq:utils:jsonata:yaml:transform` action which allows performing JSONata operations and transformations on a JSON file in the workspace.
+
+## Parse and Transform YAML
+
+This template uses the `roadiehq:utils:jsonata:yaml:transform` action which allows performing JSONata operations and transformations on a YAML file in the workspace. 

--- a/templates/roadie-utils-actions/jsonata-json.yaml
+++ b/templates/roadie-utils-actions/jsonata-json.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: Jsonata
+  title: Jsonata
+  description: Example template to perform a jsonata expression on input data
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Repository Data
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: JSON file details
+      properties:
+        path:
+          title: Path
+          type: string
+          description: Workspace path to the json file
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:plain
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+        
+    - id: jsonata
+      name: Jsonata
+      action: roadiehq:utils:jsonata:json:transform
+      input:
+        path: ${{ parameters.path}}
+        expression: '$ ~> | $ | { "items": [items, "item2"] }|'
+    
+    - id: Log
+      name: log output
+      action: debug:log
+      input:
+        message: ${{ steps.jsonata.output.result }}

--- a/templates/roadie-utils-actions/jsonata-yaml.yaml
+++ b/templates/roadie-utils-actions/jsonata-yaml.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: Jsonata
+  title: Jsonata
+  description: Example template to perform a jsonata expression on input data
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Repository Data
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: YAML file details
+      properties:
+        path:
+          title: Path
+          type: string
+          description: Workspace path to the yaml file
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:plain
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+        
+    - id: jsonata
+      name: Jsonata
+      action: roadiehq:utils:jsonata:yaml:transform
+      input:
+        path: ${{ parameters.path}}
+        expression: '$ ~> | $ | { "items": [items, "item2"] }|'
+    
+    - id: Log
+      name: log output
+      action: debug:log
+      input:
+        message: ${{ steps.jsonata.output.result }}

--- a/templates/roadie-utils-actions/read-file.yaml
+++ b/templates/roadie-utils-actions/read-file.yaml
@@ -1,0 +1,52 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: parse-file-template-example
+  title: Parse contents of a file
+  description: Example template to parse from a file on the given path in a GitHub Repository with the given content in the workspace.
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Repository Information
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: Parse From File
+      properties:
+        path:
+          title: Path
+          type: string
+          description: The path to the file
+        parser:
+          title: Parser
+          type: string
+          enum:
+            - yaml
+            - json
+            - multiyaml
+          description: The content to parse from the file
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:plain
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+    - id: parsefile
+      name: Parse File
+      action: roadiehq:utils:fs:parse
+      input:
+        path: ${{ parameters.path }}
+        parser: ${{ parameters.parser }}
+    - id: log-message
+      name: Log parsed data
+      action: debug:log
+      input:
+        message: 'File Contents: ${{ steps["parsefile"].output.content }}'

--- a/templates/roadie-utils-actions/zip-file.yaml
+++ b/templates/roadie-utils-actions/zip-file.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: zip-dummy
+  title: My custom zip action
+  description: scaffolder action to zip the current context
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Repository Data
+      properties:
+        repository:
+          title: Repository name
+          type: string
+          description: The name of the repository
+        org:
+          title: Repository Organization
+          type: string
+          description: The Github org that the repository is in
+    - title: Zip
+      properties:
+        path:
+          title: Path
+          type: string
+          description: Workspace path to zip
+        outputPath:
+          title: Path
+          type: string
+          description: The path of the zip file
+
+  steps:
+    - id: fetch-repo
+      name: Fetch repo
+      action: fetch:plain
+      input:
+        url: https://github.com/${{ parameters.org }}/${{ parameters.repository }}
+    - id: zip
+      name: Zip
+      action: roadiehq:utils:zip
+      input:
+        path: ${{ parameters.path }}
+        outputPath: ${{ parameters.outputPath }}
+    - id: log-files
+      name: List all files
+      action: debug:log
+      input:
+        listWorkspace: true


### PR DESCRIPTION
Added templates to test the following actions:
- `fs:delete`
- `fs:rename`
- `roadiehq:utils:fs:parse`
- `roadiehq:utils:zip`
- `roadiehq:utils:jsonata:yaml:transform`
- `roadiehq:utils:jsonata:yaml:transform`
