### PR TITLE
fix webhook template

### DIFF
--- a/templates/github/create-webhook/template.yaml
+++ b/templates/github/create-webhook/template.yaml
@@ -1,9 +1,9 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: publish-github-pull-request
-  title: Publish pull request to GitHub
-  description: Publish pull request to GitHub
+  name: create-github-webhook
+  title: Creates webhook for a Github repository
+  description: PCreates webhook for a Github repository
   tags:
   - github
 


### PR DESCRIPTION
Ingestion is failing because of duplicate template names "public-github-pull-request" already exists