### PR TITLE
add github-branch-protection action template

### DIFF
--- a/templates/github/branch-protection/README.md
+++ b/templates/github/branch-protection/README.md
@@ -1,0 +1,2 @@
+# Configure Branch Protection in a Github Repository
+This template uses the `github:branch-protection:create` action to configure branch protection in a Github Repository.

--- a/templates/github/branch-protection/template.yaml
+++ b/templates/github/branch-protection/template.yaml
@@ -1,0 +1,46 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: branch-protection
+  title: Configure Branch Protection in a Github Repository
+  description: Configures Branch Protection in a Github Repository
+  tags:
+  - github
+
+spec:
+  type: service
+  parameters:
+    - title: Label information
+      required: ['repoUrl']
+      properties:
+        repoUrl:
+          title: Repository URL
+          type: string
+          description: URL of the repository location
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+        branchName:
+          title: Branch Name
+          type: string
+          description: The name for the branch
+        token:
+          title: Authentication Token
+          type: string
+          ui:field: Secret
+          description: The GITHUB_TOKEN to use for authorization to GitHub
+
+  steps:
+    - id: github-pages
+      name: Configure Branch Protection
+      action: github:branch-protection:create
+      input:
+        repoUrl: ${{ parameters.repoUrl }}
+        branch: ${{ parameters.branchName }}
+        token: ${{ secrets.token }}
+
+  output:
+    text:
+      - title: GitHub Branch Protection has been configured
+        content: GitHub Branch Protection has been successfully configured for ${{ parameters.repoUrl }}


### PR DESCRIPTION
With this action, GitHub branch protect would be enabled in `<repo_url>/settings/branches` in the specified branch